### PR TITLE
Add support for Dusk 5.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     }],
     "require": {
         "facebook/webdriver": "^1.0",
-        "laravel/dusk": ">=5.0.0,<5.1",
+        "laravel/dusk": ">=5.0.0,<5.2",
         "phpunit/phpunit": "^7.1 || ^8.0",
         "symfony/process": "^4.0",
         "php": "^7.1"


### PR DESCRIPTION
With the release of Chrome 74 it was necessary for a new release of Dusk.

This pull request adds support for Dusk 5.1