### PR TITLE
Rename php-webdriver package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "role": "Developer"
     }],
     "require": {
-        "facebook/webdriver": "^1.0",
+        "php-webdriver/webdriver": "^1.0",
         "laravel/dusk": ">=5.0.0,<5.2",
         "phpunit/phpunit": "^7.1 || ^8.0",
         "symfony/process": "^4.0",


### PR DESCRIPTION
Php-webdriver package [has been renamed](https://github.com/php-webdriver/php-webdriver/issues/730#issuecomment-575601572) and the original is now marked as abandoned (and will not receive any updates).

```sh
$ composer install
Package facebook/php-webdriver is abandoned, you should avoid using it. Use php-webdriver/webdriver instead.
```